### PR TITLE
Add x-forward headers to proxied request

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Note: *This functionality was added at v1.1.0 (released 10/21/2015)*.
 ## How does it work
 It's proxying the HTTP traffic on `localPort` to `proxyPort` on all the available network interfaces and it's also [changing the origin of the host header](https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy.js#L44), allowing you to test web applications hosted by IIS Express on various remote devices (mobile devices, other desktops, etc.).
 
+If you need to access the original host requested by the browser, the request headers will include X-Forward headers. In ASP.NET, `Request.Headers["x-forwarded-host"]` will contain the requested host.
+
 ## Credits and attributions
 This command-line utility wraps [http-proxy](https://github.com/nodejitsu/node-http-proxy).
 The original [http-proxy](https://github.com/nodejitsu/node-http-proxy) logo was created by [Diego Pasquali](http://dribbble.com/diegopq).

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ Object.keys(interfaces).forEach(function(name) {
 proxy.createProxyServer({
   target: protocolPrefix + host + ':' + port,
   secure: false,
-  changeOrigin: true
+  changeOrigin: true,
+  xfwd: true
 }).listen(proxyPort, function() {
   console.log('Listening... [press Control-C to exit]');
 }).on('error', function (err, req, res) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iisexpress-proxy",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A simple local proxy useful for accessing IIS Express from remote machines.",
   "preferGlobal": true,
   "main": "index.js",


### PR DESCRIPTION
Proxied requests have the original host re-written as localhost. Because of this certain scenarios, such as varying content based on the requested host (as in a multi-tenant system where the host identifies the tenant) are not possible to test when using IIS-Express locally.

This change preserves the host details for inspection by passing the xfwd option to node-http-proxy which adds x-forwarded headers. In ASP.NET, if the host header is localhost, we can fall back to the x-forwarded-host header instead.

I've updated the ReadMe and Version number as well as adding the xfwd parameter. This change should be non-breaking.