### PR TITLE
Adding error event handler for proxy so errors don't terminate

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ var proxy = new httpProxy.createProxyServer({
   secure: false,
   changeOrigin: true,
   xfwd: true
+}).on('error', function (err) {
+  console.log(err);
+  console.log('Listening... [press Control-C to exit]');
 });
 var proxyServer = http.createServer(function (req, res) {
   proxy.web(req, res);


### PR DESCRIPTION
Added an error event handler to the `proxy` object. For some reason I keep getting the following error when running my puppeteer tests:
```
PS> node .\index.js 12345 to 3000
IIS Express Proxy 1.4.0
Proxying http://localhost:12345 to network interfaces:
        Ethernet: 192.168.0.1:3000
Listening... [press Control-C to exit]

{ I run my tests here }

C:\Users\sjasperse\Development\iisexpress-proxy\node_modules\http-proxy\lib\http-proxy\index.js:120
    throw err;
    ^

Error: read ECONNRESET
    at _errnoException (util.js:992:11)
    at TCP.onread (net.js:618:25)
```

Adding this handler makes the output noisy, but it prevents node from terminating due to unhandled errors.