### PR TITLE
Adds option to enable proxied hosts to use redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ var proxy = new httpProxy.createProxyServer({
   },
   secure: false,
   changeOrigin: true,
-  xfwd: true
+  xfwd: true,
+  followRedirects: true
 }).on('error', function (err) {
   console.log(err);
   console.log('Listening... [press Control-C to exit]');


### PR DESCRIPTION
Adds `followRedirects: true` to the httpProxy setup, which allows scenarios where the host issues redirects. For issue #13