### PR TITLE
Removes `followRedirects: true`, adds `autoRewrite: true` instead. #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,15 +53,11 @@ Object.keys(interfaces).forEach(function(name) {
 });
 
 var proxy = new httpProxy.createProxyServer({
-  target: {
-    host: host,
-    port: port,
-    protocol: protocolPrefix
-  },
+  target: protocolPrefix + host + ':' + port,
   secure: false,
   changeOrigin: true,
   xfwd: true,
-  followRedirects: true
+  autoRewrite: true
 }).on('error', function (err) {
   console.log(err);
   console.log('Listening... [press Control-C to exit]');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iisexpress-proxy",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "A simple local proxy useful for accessing IIS Express from remote machines.",
   "preferGlobal": true,
   "main": "index.js",


### PR DESCRIPTION
The previous fix for #13 (`followRedirects: true`) creates unwanted behavior: handling redirects internally. This breaks _my_ software because the browser needs to be aware of that redirect, and update its address bar accordingly for relative hrefs to resolve correctly.

For example:

```
Without followRedirects
GET / -> 302 Location: /home/ljenkins/
GET /home/ljenkins/ -> <a href="profile">
GET /home/ljenkins/profile -> 200

With followRedirects: true
GET / -> 302 Location: /home/ljenkins/ -> Internally GET /home/ljenkins/ -> <a href="profile">
GET /profile -> 404
```

`autoRewrite` is an option built into `http-proxy` which rewrites the host portion of the Location header to the request host if Location's host matches the target host. [See the relevant code here](https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/passes/web-outgoing.js#L64)