### PR TITLE
Allow serving on HTTPS and specifying serving address

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ The program will list the external addresses you can use for testing your applic
 
 Note that this will terminate HTTPS. On your destination machine, connect to port `3000` using HTTP, not HTTPS.
 
+If you want the proxy itself to server HTTPS, you can specify the target with the full URL as well.
+
+    iisexpress-proxy https://localhost:51123 to https://*:3000
+
+This will generate a self-signed certificate and use it, openssl must be in `PATH` for this to work.
+
+If you want to bind to a specific interface instead of all of them, use its IP in the target URL, e.g. `https://10.0.0.1:3000`.
+
 ## Advanced usage (VPN, virtual hosts, etc.)
 
 You can also use **iisexpress-proxy** to expose an IIS server instance running on a **different host** accessible through VPN, like this:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Note that this will terminate HTTPS. On your destination machine, connect to por
 
 You can also use **iisexpress-proxy** to expose an IIS server instance running on a **different host** accessible through VPN, like this:
 
-    iisexpress-proxy host:port to proxyPort
+    iisexpress-proxy host:port to proxyHost:proxyPort
 
 For instance, let's conside this scenario:
 
@@ -58,9 +58,16 @@ For instance, let's conside this scenario:
 
 By running this in the Command Prompt:
 
-    iisexpress-proxy 192.168.96.3:5000 to 3000
+    iisexpress-proxy 192.168.96.3:5000 to 192.168.0.102:3000
 
 ...you'll be able to access the application by pointing the mobile devices to 192.168.0.102:3000.
+
+For another advanced example, consider that you're on public Wifi and don't want to publicly expose your dev server. You could
+set up a VPN between your laptop and your phone and only expose the server on the VPN interface (10.0.0.1). Then you can run
+
+    iisexpress-proxy 5000 to 10.0.0.1:8080
+
+...and open http://10.0.0.1:8080 on your phone with VPN enabled, while other wifi users won't be able to connect.
 
 Note: _This functionality was added at v1.1.0 (released 10/21/2015)_.
 

--- a/generate-cert.js
+++ b/generate-cert.js
@@ -1,0 +1,28 @@
+// Generate a self-signed certificate, openssl has to be in PATH.
+
+var os = require('os'),
+    fs = require('fs'),
+    path = require('path'),
+    process = require('process'),
+    { execSync } = require('child_process');
+
+exports.getTempSSLCert = function() {
+  var tmpDir = os.tmpdir();
+  var certPath = path.join(tmpDir, 'iisexpress-proxy-cert.pem');
+  var csrPath = path.join(tmpDir, 'iisexpress-proxy-csr.pem');
+  var keyPath = path.join(tmpDir, 'iisexpress-proxy-key.pem');
+  if (!fs.existsSync(certPath) || !fs.existsSync(keyPath)) {
+    try {
+      execSync(`openssl genrsa -out "${keyPath}"`, {});
+      execSync(`openssl req -new -batch -key "${keyPath}" -out "${csrPath}"`);
+      execSync(`openssl x509 -req -days 9999 -in "${csrPath}" -signkey "${keyPath}" -out "${certPath}"`);
+    } catch (err) {
+      console.error('Failed to generate SSL cert, make sure openssl is in PATH.\n\n' + err);
+    }
+  }
+
+  return {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath),
+  };
+}

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var exit = function() {
   var bin = Object.keys(pkg.bin)[0];
   console.log('Usage examples:');
   console.log('\t%s 51123 to 3000', bin);
-  console.log('\t%s [http(s)://]192.168.0.100:51123 to 3000', bin);
+  console.log('\t%s [http(s)://]192.168.0.100:51123 to 10.0.0.1:3000', bin);
   console.log('\t%s [http://]domain.com:80 to 3000', bin);
   console.log('\t%s [https://]ssl-domain.com:443 to 3000', bin);
   console.log();
@@ -22,38 +22,54 @@ if (process.argv.length != 5 || process.argv[3].toLowerCase() !== 'to') {
   exit();
 }
 
-var source = process.argv[2].match(/^(https?:\/\/)?(.+?)(?:\:(\d+))$/);
-var protocolPrefix = 'http://',
-    host = 'localhost',
-    port, proxyPort;
+var urlRegExp = /^(https?:\/\/)?(.+?)(?:\:(\d+))$/;
+var sourceMatch = process.argv[2].match(urlRegExp);
+var targetMatch = process.argv[4].match(urlRegExp);
 
-if (source === null) {
-  port = parseInt(process.argv[2], 10);
-} else {
-  protocolPrefix = source[1] || 'https://';
-  host = source[2];
-  port = parseInt(source[3], 10);
+var source = {
+  protocol: 'http://',
+  host: 'localhost',
+  port: 58106,
 }
-proxyPort = parseInt(process.argv[4], 10);
+var target = {
+  protocol: 'http://',
+  host: '*',
+  port: 8080,
+}
 
-if (isNaN(port) || isNaN(proxyPort)) {
+if (sourceMatch === null) {
+  source.port = parseInt(process.argv[2], 10);
+} else {
+  source.protocol = sourceMatch[1] || 'http://';
+  source.host = sourceMatch[2];
+  source.port = parseInt(sourceMatch[3], 10);
+}
+if (targetMatch === null) {
+  target.port = parseInt(process.argv[4], 10);
+} else {
+  target.protocol = targetMatch[1] || 'http://';
+  target.host = targetMatch[2];
+  target.port = parseInt(targetMatch[3], 10);
+}
+
+if (isNaN(source.port) || isNaN(target.port)) {
   exit();
 }
 
-console.log('Proxying %s%s:%d to network interfaces:', protocolPrefix, host, port);
+console.log('Proxying %s%s:%d to network interfaces:', source.protocol, source.host, source.port);
 
 var interfaces = os.networkInterfaces();
 
 Object.keys(interfaces).forEach(function(name) {
   interfaces[name].filter(function(item) {
-    return item.family == 'IPv4' && !item.internal;
+    return item.family == 'IPv4' && !item.internal && (target.host == item.address || target.host === '*');
   }).forEach(function(item) {
-    console.log("\t%s: %s:%s", name, item.address, proxyPort);
+    console.log("\t%s: %s%s:%s", name, target.protocol, item.address, target.port);
   });
 });
 
 var proxy = new httpProxy.createProxyServer({
-  target: protocolPrefix + host + ':' + port,
+  target: source.protocol + source.host + ':' + source.port,
   secure: false,
   changeOrigin: true,
   xfwd: true,
@@ -69,7 +85,8 @@ proxyServer.on('upgrade', function (req, socket, head) {
   proxy.ws(req, socket, head);
 });
 
-proxyServer.listen(proxyPort, function() {
+var listenHost = target.host === '*' ? '0.0.0.0' : target.host;
+proxyServer.listen(target.port, listenHost, function() {
   console.log('Listening... [press Control-C to exit]');
 }).on('error', function (err, req, res) {
   console.log(err.stack);


### PR DESCRIPTION
Two QoL features that I felt were missing:
 - You can now specify what address the proxy server will bind to, so you don't have to serve it on every single network interface you have.
 - It can now generate self-signed certs and serve on HTTPS, some things require HTTPS for debugging.