### PR TITLE
Clarify help and docs around openssl and network interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 .DS_Store
 yarn.lock
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ The program will list the external addresses you can use for testing your applic
 
 Note that this will terminate HTTPS. On your destination machine, connect to port `3000` using HTTP, not HTTPS.
 
-If you want the proxy itself to server HTTPS, you can specify the target with the full URL as well.
+If you want the proxy itself to serve HTTPS, you can specify the target with the full URL as well.
 
     iisexpress-proxy https://localhost:51123 to https://*:3000
 
 This will generate a self-signed certificate and use it, openssl must be in `PATH` for this to work.
 
-If you want to bind to a specific interface instead of all of them, use its IP in the target URL, e.g. `https://10.0.0.1:3000`.
+*If you're on Windows, the easiest way to get openssl is to use Git Bash that comes with it pre-installed.*
+
+If you want to bind to a specific interface instead of all of them, use its IP in the target URL, e.g. `https://10.0.0.1:3000`. Note that the right-hand part cannot be a domain name.
 
 ## Advanced usage (VPN, virtual hosts, etc.)
 

--- a/generate-cert.js
+++ b/generate-cert.js
@@ -17,7 +17,9 @@ exports.getTempSSLCert = function() {
       execSync(`openssl req -new -batch -key "${keyPath}" -out "${csrPath}"`);
       execSync(`openssl x509 -req -days 9999 -in "${csrPath}" -signkey "${keyPath}" -out "${certPath}"`);
     } catch (err) {
-      console.error('Failed to generate SSL cert, make sure openssl is in PATH.\n\n' + err);
+      console.log(err + '\n');
+      console.log('Failed to generate SSL cert, make sure the "openssl" command is in PATH.\nIf you\'re on Windows, we recommend running iisexpress-proxy in Git Bash, which comes with openssl pre-installed.');
+      process.exit(1);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,14 @@ var os = require('os'),
 
 var exit = function() {
   var bin = Object.keys(pkg.bin)[0];
-  console.log('Usage examples:');
+  console.log('Usage:');
+  console.log('\t%s <SOURCE_TO_PROXY> to <PROXY_ENDPOINT>', bin);
+  console.log('\tBoth arguments can be port number, or address with port number with optional protocol');
+  console.log('\tIf no address is specified in SOURCE_TO_PROXY, it defaults to localhost.');
+  console.log('\tIf no address is specified for PROXY_ENDPOINT or it\'s "*", it will listen on all network interfaces');
+  console.log('\tIf you specify the address for PROXY_ENDPOINT (and not just port), it must be');
+  console.log('\tthe IP address of an existing network interface and cannot be a domain name.');
+  console.log('\nUsage examples:');
   console.log('\t%s 51123 to 3000', bin);
   console.log('\t%s 192.168.0.100:51123 to 10.0.0.1:3000', bin);
   console.log('\t%s [http(s)://]domain.com:80 to 3000', bin);


### PR DESCRIPTION
Clarifies that you cannot use a domain name as proxy endpoint and adds the hint to use Git Bash if you're missing openssl on Windows.

Closes #32.